### PR TITLE
fix: tailing loop silently dropped lines on bursts of new data

### DIFF
--- a/src/readers/backseeking.rs
+++ b/src/readers/backseeking.rs
@@ -118,21 +118,17 @@ impl BackSeekingProcessor {
         // Set our position in the file based on offset unit.
         match units {
             config::OffsetUnit::Lines => {
-                if offset > 0 {
-                    // Positive offset: skip N lines from the beginning,
-                    // which we do NOT do here
-                    file.seek(io::SeekFrom::Start(0))?;
-                } else if offset < 0 {
+                if offset < 0 {
                     // Negative offset: start N lines from the end
                     let start = self.move_n_lines_back(&mut file, (-offset) as u64)?;
                     file.seek(io::SeekFrom::Start(start))?;
-                } else if tailing {
-                    // Zero offset: start from the end (no lines to show unless tailing)
+                } else if offset == 0 && tailing {
+                    // Zero offset while tailing: start from the end (show only new data)
                     file.seek(io::SeekFrom::End(0))?;
                 }
+                // Positive offset: caller handles forward-skipping lines
             }
             config::OffsetUnit::Bytes => {
-                // Byte-based offset
                 if offset > 0 {
                     // Positive offset: skip N bytes from the beginning
                     file.seek(io::SeekFrom::Start(offset as u64))?;
@@ -140,7 +136,7 @@ impl BackSeekingProcessor {
                     // Negative offset: start N bytes from the end
                     file.seek(io::SeekFrom::End(offset))?;
                 } else if tailing {
-                    // Zero offset: start from the end
+                    // Zero offset while tailing: start from the end
                     file.seek(io::SeekFrom::End(0))?;
                 }
             }
@@ -262,46 +258,33 @@ impl BackSeekingProcessor {
             return Ok(());
         }
 
-        // Now we tell a tale of tailing.
+        // Keep the same BufReader alive across the polling loop so its internal
+        // buffer stays consistent with the file position. Re-creating BufReader
+        // each iteration caused it to read-ahead up to 8KB, advance the OS file
+        // position, and then stream_position() would record that inflated offset,
+        // silently skipping all the lines that were buffered but not yet consumed.
         let mut last_flush = Instant::now();
 
-        // Get the file back from the reader
-        let mut file = reader.into_inner();
-        let mut file_position = file.stream_position().into_diagnostic()?;
-
-        // Polling loop for file growth detection
-        // Note: Could be enhanced with inotify/file system events for efficiency
         loop {
-            std::thread::sleep(Duration::from_millis(100));
-
-            // Check if file has grown
-            let current_size = file.seek(io::SeekFrom::End(0)).into_diagnostic()?;
-            if current_size > file_position {
-                // Hide and seek, trains and sewing machines.
-                file.seek(io::SeekFrom::Start(file_position)).into_diagnostic()?;
-                let mut tail_reader = BufReader::new(&file);
-
-                match tail_reader.read_line(&mut line).into_diagnostic()? {
-                    0 => {
-                        // EOF - no new data available, continue polling
-                        continue;
+            match reader.read_line(&mut line).into_diagnostic()? {
+                0 => {
+                    // EOF - no new data yet; flush pending output and poll again
+                    if last_flush.elapsed() >= TAIL_FLUSH_INTERVAL {
+                        self.outlock.flush().into_diagnostic()?;
+                        last_flush = Instant::now();
                     }
-                    _ => {
-                        strip_line_ending(&mut line);
-                        // New data available - process it.
-                        process_line(&line, &mut self.buffer, &mut self.outlock)?;
-                        if last_flush.elapsed() >= TAIL_FLUSH_INTERVAL {
-                            self.outlock.flush().into_diagnostic()?;
-                            last_flush = Instant::now();
-                        }
-
-                        line.clear();
-                        self.buffer.clear();
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+                _ => {
+                    strip_line_ending(&mut line);
+                    process_line(&line, &mut self.buffer, &mut self.outlock)?;
+                    line.clear();
+                    self.buffer.clear();
+                    if last_flush.elapsed() >= TAIL_FLUSH_INTERVAL {
+                        self.outlock.flush().into_diagnostic()?;
+                        last_flush = Instant::now();
                     }
                 }
-
-                // Note where we finished reading so we can figure out if we get more.
-                file_position = file.stream_position().into_diagnostic()?;
             }
         }
     }
@@ -310,6 +293,49 @@ impl BackSeekingProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn move_to_position_tailing_zero_offset_starts_at_end() {
+        use std::io::{Read, Write};
+
+        use tempfile::NamedTempFile;
+
+        let mut temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        temp_file
+            .write_all(b"line1\nline2\nline3\n")
+            .expect("Failed to write to temp file");
+
+        let mut processor = BackSeekingProcessor::new(PathBuf::from(temp_file.path()));
+        let mut file = processor
+            .move_to_position(0, config::OffsetUnit::Lines, true)
+            .expect("move_to_position should succeed");
+
+        // tailing with no offset starts at EOF: nothing to read until new data arrives
+        let mut result = String::new();
+        file.read_to_string(&mut result).expect("Failed to read file");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn move_to_position_negative_offset_seeks_from_end() {
+        use std::io::{Read, Write};
+
+        use tempfile::NamedTempFile;
+
+        let mut temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        temp_file
+            .write_all(b"line1\nline2\nline3\nline4\nline5\n")
+            .expect("Failed to write to temp file");
+
+        let mut processor = BackSeekingProcessor::new(PathBuf::from(temp_file.path()));
+        let mut file = processor
+            .move_to_position(-2, config::OffsetUnit::Lines, false)
+            .expect("move_to_position should succeed");
+
+        let mut result = String::new();
+        file.read_to_string(&mut result).expect("Failed to read file");
+        assert_eq!(result, "line4\nline5\n");
+    }
 
     #[test]
     fn seeking_backwards() {

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -248,8 +248,9 @@ pub fn create_file_processor<P: AsRef<Path>>(
             || (file_size > CHUNKED_WITH_OFFSET_FILE_SIZE && large_offset)
             || file_size > ALWAYS_CHUNKED_FILE_SIZE);
 
-    // This is the only reader that can handle negative and byte offsets.
-    if offset < 0 || matches!(offset_unit, config::OffsetUnit::Bytes) {
+    // This is the only reader that can handle negative and byte offsets,
+    // and it's also the only reader with a tail-following loop.
+    if offset < 0 || matches!(offset_unit, config::OffsetUnit::Bytes) || config::tailing() {
         let processor = BackSeekingProcessor::new(PathBuf::from(path));
         return Ok(FileProcessorType::BackSeeking(processor));
     }

--- a/tests/tailing.rs
+++ b/tests/tailing.rs
@@ -1,0 +1,58 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use tempfile::NamedTempFile;
+
+/// Verify that tailing a file delivers every line without gaps, including lines
+/// appended in a burst after the initial read.
+///
+/// This exercises the polling loop in BackSeekingProcessor. Previously, a new
+/// BufReader was created on each loop iteration: BufReader reads up to 8KB
+/// ahead, advancing the OS file position past many lines at once. When it was
+/// dropped after consuming just one line, stream_position() recorded that
+/// inflated offset and the next iteration seeked past all the buffered lines.
+#[test]
+fn tailing_delivers_every_line() {
+    let mut file = NamedTempFile::new().expect("failed to create temp file");
+
+    // Write content before spawning — tale -f with no -n seeks to EOF at
+    // startup, so these lines are intentionally not shown.
+    for i in 0..5_usize {
+        writeln!(file, r#"{{"level":"INFO","message":"msg-{i:02}"}}"#).expect("failed to write initial line");
+    }
+    file.flush().expect("failed to flush initial lines");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tale"))
+        .args(["-f", file.path().to_str().expect("path must be valid utf-8")])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn tale");
+
+    // Let it start and reach EOF.
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Append a burst of lines. The old code would skip most of these because
+    // BufReader's 8KB read-ahead advanced the OS file position past all of
+    // them in a single iteration, then stream_position() captured that
+    // inflated offset.
+    for i in 5..15_usize {
+        writeln!(file, r#"{{"level":"INFO","message":"msg-{i:02}"}}"#).expect("failed to write appended line");
+    }
+    file.flush().expect("failed to flush appended lines");
+
+    // Give the polling loop (100ms tick) time to pick everything up.
+    std::thread::sleep(Duration::from_millis(500));
+
+    child.kill().expect("failed to kill tale");
+    let output = child.wait_with_output().expect("failed to collect output");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Only the appended lines should appear — the pre-spawn content is skipped
+    // because tale -f starts at EOF when no -n offset is given.
+    for i in 5..15_usize {
+        let marker = format!("msg-{i:02}");
+        assert!(stdout.contains(&marker), "output missing {marker};\nstdout:\n{stdout}");
+    }
+}


### PR DESCRIPTION
BufReader reads up to 8KB ahead on each fill. The old polling loop created a new BufReader per iteration, consumed one line, then dropped it. The OS file position had already advanced by up to 8KB, so stream_position() recorded that inflated offset and the next iteration seeked past all the buffered lines.

Fix: keep the same BufReader alive for the lifetime of the tailing loop. When read_line returns 0 (EOF), sleep and retry — the reader picks up new data naturally as the file grows, with no manual seeking needed.

The tale -f seek-to-end behaviour for offset=0 is preserved: attaching to a live file still starts at EOF and follows only new data.

Add two unit tests for move_to_position and one integration test that spawns the binary, appends a burst of lines, and asserts every appended line appears in output.